### PR TITLE
Remove eslint-config-prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,6 @@ const config = {
 		'plugin:react/recommended',
 		'plugin:react-hooks/recommended',
 		'plugin:@next/next/core-web-vitals',
-		'prettier',
 	],
 	plugins: [
 		'@typescript-eslint',

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
 		"autoprefixer": "10.4.19",
 		"cssnano": "6.1.2",
 		"eslint": "8.57.0",
-		"eslint-config-prettier": "9.1.0",
 		"eslint-import-resolver-typescript": "3.6.1",
 		"eslint-plugin-jsx-a11y": "6.8.0",
 		"eslint-plugin-react": "7.34.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ devDependencies:
   eslint:
     specifier: 8.57.0
     version: 8.57.0
-  eslint-config-prettier:
-    specifier: 9.1.0
-    version: 9.1.0(eslint@8.57.0)
   eslint-import-resolver-typescript:
     specifier: 3.6.1
     version: 3.6.1(@typescript-eslint/parser@7.4.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
@@ -2742,15 +2739,6 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /eslint-config-prettier@9.1.0(eslint@8.57.0):
-    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.57.0
     dev: true
 
   /eslint-import-resolver-node@0.3.9:


### PR DESCRIPTION
ESLint deprecated formatting rules. So I dropped https://github.com/prettier/eslint-config-prettier.

## Refs

- [Deprecation of formatting rules](https://eslint.org/blog/2023/10/deprecating-formatting-rules/)