### PR TITLE
Dropped Node.js < v18.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"workerDirectory": "public"
 	},
 	"engines": {
-		"node": "^18.17.0"
+		"node": "^18.18.0"
 	},
 	"packageManager": "pnpm@8.15.6",
 	"dependencies": {


### PR DESCRIPTION
https://eslint.org/blog/2024/04/eslint-v9.0.0-released/#node.js-%3C-v18.18.0%2C-v19-no-longer-supported