### PR TITLE
Enable pnpm version management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+manage-package-manager-versions=true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This is [my portfolio site](https://roottool.vercel.app). I use the below stacks
 - Next.js
 - TypeScript
 
+## Setting up the environment
+
+Run `pnpm install` in the root of your cloned repository.
+
 ## License
 
 [MIT license](LICENSE)


### PR DESCRIPTION
SSIA

> Added pnpm version management. If the `manage-package-manager-versions` setting is set to `true`, pnpm will switch to the version specified in the `packageManager` field of `package.json` [#8363](https://github.com/pnpm/pnpm/pull/8363). This is the same field used by Corepack.
> 
> https://github.com/pnpm/pnpm/releases/tag/v9.7.0