### PR TITLE
chore: Update build configuration and TypeScript settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Development Workflow
 
 - **Development server**: `pnpm run dev` (Next.js dev server)
-- **Build**: `pnpm run build` (runs clean + parallel build tasks)
+- **Build**: `pnpm run build` (Next.js build task)
 - **Production server**: `pnpm run start`
-- **Clean**: `pnpm run clean` (removes .next and .swc directories)
 
 ### Code Quality
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,10 +6,11 @@ import jsxA11yPlugin from 'eslint-plugin-jsx-a11y'
 import reactPlugin from 'eslint-plugin-react'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
 import unusedImports from 'eslint-plugin-unused-imports'
+import { defineConfig } from 'eslint/config'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
-export default tseslint.config(
+export default defineConfig(
 	gitignore({ root: true }),
 	{
 		ignores: ['pnpm-lock.yaml', 'public'],

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,14 +8,16 @@ pre-commit:
   skip:
     - merge
     - rebase
-  commands:
-    jsts:
+  jobs:
+    - name: jsts
       glob: '*.{?(c|m)js,jsx,?(c|m)ts,tsx}'
-      run: |
-        pnpm exec eslint --color --fix {staged_files} &&
-        pnpm exec prettier --write {staged_files}
+      group:
+        piped: true
+        jobs:
+          - run: pnpm exec eslint --cache --color --fix {staged_files}
+          - run: pnpm exec prettier --cache --write {staged_files}
       stage_fixed: true
-    only-pretter:
+    - name: only prettier
       glob: '*.{md,json,y?(a)ml}'
-      run: pnpm exec prettier --write {staged_files}
+      run: pnpm exec prettier --cache --write {staged_files}
       stage_fixed: true

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@
  */
 const nextConfig = {
 	reactStrictMode: true,
+	typedRoutes: true,
 	pageExtensions: ['page.tsx', 'api.ts'],
 	images: {
 		remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -17,10 +17,8 @@
     "url": "https://github.com/roottool/portfolio/issues"
   },
   "scripts": {
-    "clean": "rimraf .next .swc",
     "dev": "next dev",
-    "build": "npm-run-all clean --parallel build:*",
-    "build:next": "next build",
+    "build": "next build",
     "start": "next start",
     "lint": "run-s -c lint:*",
     "lint:prettier": "prettier --check .",
@@ -92,7 +90,6 @@
     "npm-run-all2": "8.0.4",
     "postcss": "8.5.6",
     "prettier": "3.6.2",
-    "rimraf": "6.0.1",
     "tailwindcss": "4.1.13",
     "typescript": "5.9.2",
     "typescript-eslint": "8.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       prettier:
         specifier: 3.6.2
         version: 3.6.2
-      rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
       tailwindcss:
         specifier: 4.1.13
         version: 4.1.13
@@ -658,14 +655,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2069,11 +2058,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -2307,10 +2291,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
-    engines: {node: 20 || >=22}
-
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
 
@@ -2521,10 +2501,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
-    engines: {node: 20 || >=22}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2570,10 +2546,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2729,10 +2701,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -3027,11 +2995,6 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   rollup@4.46.2:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
@@ -3954,12 +3917,6 @@ snapshots:
   '@inquirer/type@3.0.8(@types/node@22.18.1)':
     optionalDependencies:
       '@types/node': 22.18.1
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5501,15 +5458,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.0.3
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
   globals@14.0.0: {}
 
   globals@16.3.0: {}
@@ -5738,10 +5686,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   javascript-natural-sort@0.7.1: {}
 
   jiti@2.5.1: {}
@@ -5900,8 +5844,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
-
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5942,10 +5884,6 @@ snapshots:
       picomatch: 2.3.1
 
   min-indent@1.0.1: {}
-
-  minimatch@10.0.3:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.1.2:
     dependencies:
@@ -6116,11 +6054,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.1.0
       minipass: 7.1.2
 
   path-to-regexp@6.3.0: {}
@@ -6392,11 +6325,6 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.0.3
-      package-json-from-dist: 1.0.1
 
   rollup@4.46.2:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2023",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,10 +31,9 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "$/*": ["public/*"]
+      "@/*": ["./src/*"],
+      "$/*": ["./public/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

This PR updates various build and development configuration files to improve the development experience and modernize the toolchain.

## Changes

### ESLint Configuration
- Migrate from `tseslint.config` to `defineConfig` for better type safety and IDE support
- Import `defineConfig` from `eslint/config`

### Build Process Simplification
- Remove `rimraf` dependency and related clean scripts
- Simplify build command to use Next.js built-in build process
- Remove unnecessary parallel build tasks

### TypeScript Configuration
- Update `target` from `es2018` to `es2023` for modern JavaScript features
- Remove `baseUrl` and update path mappings to use relative paths
- Enable `typedRoutes` in Next.js configuration for better type safety

### Development Tools
- Improve Lefthook configuration with job grouping and piped execution
- Add caching flags to ESLint and Prettier for better performance
- Update hook structure for better organization

### Documentation
- Update CLAUDE.md to reflect simplified build process
- Remove references to removed scripts and dependencies

## Test Plan

- [x] Verify build process works: `pnpm run build`
- [x] Verify linting works: `pnpm run lint`
- [x] Verify formatting works: `pnpm run format`
- [x] Verify type checking works: `pnpm run typecheck`
- [x] Verify development server starts: `pnpm run dev`

🤖 Generated with [Claude Code](https://claude.ai/code)