### PR TITLE
chore: Add `resolve.tsconfigPaths` option

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,8 @@ export default defineConfig({
 	output: "static",
 	vite: {
 		plugins: [tailwindcss()],
+		resolve: {
+			tsconfigPaths: true,
+		},
 	},
 });


### PR DESCRIPTION
## Overview

Enable Vite's built-in TypeScript path alias resolution by adding `resolve.tsconfigPaths: true` to the Vite config.

## Motivation

Without this option, path aliases defined in `tsconfig.json` (e.g., `@/*` → `src/*`, `$/*` → `public/*`) are not resolved by Vite at dev/build time, requiring a separate plugin.

## Changes

- Enabled `resolve.tsconfigPaths` in the Vite section of `astro.config.mjs` so path aliases from `tsconfig.json` are resolved natively

## Testing

- [x] Build verification
- [x] Lint/format checks passed

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>