### PR TITLE
feat: migrate formatter from dprint to oxfmt (except Astro files)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,14 @@ jobs:
             .github/renovate.json
             package.json
             bun.lock
-            dprint.jsonc
+            .oxfmtrc.json
           sparse-checkout-cone-mode: false
 
       - name: Initialize
         uses: ./.github/actions/setup-environment
 
-      - name: Check format by dprint
-        run: bunx dprint check .github/renovate.json
+      - name: Check format by oxfmt
+        run: bunx oxfmt --check .github/renovate.json
 
       - name: Validate Renovate config
         run: bunx -p renovate renovate-config-validator --strict
@@ -105,7 +105,10 @@ jobs:
       - name: Initialize
         uses: ./.github/actions/setup-environment
 
-      - name: Run format check
+      - name: Run format check (oxfmt)
+        run: bun run lint:oxfmt
+
+      - name: Run format check (dprint)
         run: bun run lint:dprint
 
       - name: Run lint

--- a/.github/workflows/update-oss-contributions.yml
+++ b/.github/workflows/update-oss-contributions.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Format and move JSON
         run: |
-          bunx dprint fmt temp-contributions.json
+          bunx oxfmt temp-contributions.json
           mv temp-contributions.json src/assets/oss-contributions.json
 
       - name: Check for changes

--- a/.github/workflows/update-owned-games.yml
+++ b/.github/workflows/update-owned-games.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Format and move JSON
         run: |
-          bunx dprint fmt temp-owned-games.json
+          bunx oxfmt temp-owned-games.json
           mv temp-owned-games.json src/assets/owned-games.json
 
       - name: Check for changes

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,14 @@
+{
+	"useTabs": true,
+	"printWidth": 100,
+	"ignorePatterns": ["public/", "src/assets/", ".serena/", ".claude/", ".mcp.json", "**/*.astro"],
+	"overrides": [
+		{
+			"files": ["**/*.{yml,yaml,md}"],
+			"options": {
+				"useTabs": false,
+				"tabWidth": 2
+			}
+		}
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,8 @@
 		"editorconfig.editorconfig",
 		// * JavaScript, TypeScript
 		"dbaeumer.vscode-eslint",
+		"oxc.oxc-vscode",
+		// * Astro (dprint formats .astro files only)
 		"dprint.dprint",
 		"astro-build.astro-vscode"
 		// "ZixuanChen.vitest-explorer",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,8 +15,11 @@
 	"files.trimTrailingWhitespace": true,
 	"js/ts.preferences.importModuleSpecifier": "non-relative",
 	"js/ts.preferences.importModuleSpecifierEnding": "minimal",
-	"[astro|javascript|typescript|typescriptreact|json|jsonc|yaml]": {
+	"[astro]": {
 		"editor.defaultFormatter": "dprint.dprint"
+	},
+	"[javascript|typescript|typescriptreact|json|jsonc|yaml]": {
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	},
 	"json.schemas": [
 		{
@@ -27,7 +30,7 @@
 		}
 	],
 	"[markdown]": {
-		"editor.defaultFormatter": "dprint.dprint",
+		"editor.defaultFormatter": "oxc.oxc-vscode",
 		"editor.wordWrap": "on",
 		"editor.quickSuggestions": {
 			"comments": "off",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,12 @@ This file provides guidance to AI coding assistants when working with code in th
 
 ### Code Quality
 
-- **Lint**: `bun run lint` (runs ESLint + dprint checks in sequence)
-  - `bun run lint:dprint` - dprint format check
-  - `bun run lint:eslint` - ESLint check
-- **Format**: `bun run format` (formats code with dprint)
-- **Fix**: `bun run fix` (auto-fixes ESLint issues + formats with dprint)
+- **Lint**: `bun run lint` (runs format checks + oxlint/ESLint + Markuplint in sequence)
+  - `bun run lint:oxfmt` - oxfmt format check (all files except `.astro`)
+  - `bun run lint:dprint` - dprint format check (`.astro` files only)
+  - `bun run lint:oxeslint` - Astro check + oxlint + ESLint check
+- **Format**: `bun run format` (formats code with oxfmt + dprint)
+- **Fix**: `bun run fix` (auto-fixes oxlint/ESLint issues + formats)
 - **Type check**: `bun run typecheck` (runs both Astro check and TypeScript compiler)
   - `bun run typecheck:astro` - Astro check (TypeScript + template validation)
   - `bun run typecheck:tsc` - TypeScript compiler check

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "globals": "17.6.0",
         "markuplint": "4.18.3",
         "npm-run-all2": "9.0.1",
+        "oxfmt": "0.54.0",
         "oxlint": "1.68.0",
         "oxlint-tsgolint": "0.23.0",
         "satori": "0.26.0",
@@ -286,6 +287,44 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.54.0", "", { "os": "android", "cpu": "arm64" }, "sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.54.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.54.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.54.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.54.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.54.0", "", { "os": "linux", "cpu": "arm" }, "sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.54.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.54.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.54.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.54.0", "", { "os": "linux", "cpu": "none" }, "sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.54.0", "", { "os": "linux", "cpu": "none" }, "sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.54.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.54.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.54.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.54.0", "", { "os": "none", "cpu": "arm64" }, "sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.54.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.54.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw=="],
 
@@ -1079,6 +1118,8 @@
 
     "os-locale": ["os-locale@6.0.2", "", { "dependencies": { "lcid": "^3.1.1" } }, "sha512-qIb8bzRqaN/vVqEYZ7lTAg6PonskO7xOmM7OClD28F6eFa4s5XGe4bGpHUHMoCHbNNuR0pDYFeSLiW5bnjWXIA=="],
 
+    "oxfmt": ["oxfmt@0.54.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.54.0", "@oxfmt/binding-android-arm64": "0.54.0", "@oxfmt/binding-darwin-arm64": "0.54.0", "@oxfmt/binding-darwin-x64": "0.54.0", "@oxfmt/binding-freebsd-x64": "0.54.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.54.0", "@oxfmt/binding-linux-arm-musleabihf": "0.54.0", "@oxfmt/binding-linux-arm64-gnu": "0.54.0", "@oxfmt/binding-linux-arm64-musl": "0.54.0", "@oxfmt/binding-linux-ppc64-gnu": "0.54.0", "@oxfmt/binding-linux-riscv64-gnu": "0.54.0", "@oxfmt/binding-linux-riscv64-musl": "0.54.0", "@oxfmt/binding-linux-s390x-gnu": "0.54.0", "@oxfmt/binding-linux-x64-gnu": "0.54.0", "@oxfmt/binding-linux-x64-musl": "0.54.0", "@oxfmt/binding-openharmony-arm64": "0.54.0", "@oxfmt/binding-win32-arm64-msvc": "0.54.0", "@oxfmt/binding-win32-ia32-msvc": "0.54.0", "@oxfmt/binding-win32-x64-msvc": "0.54.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ=="],
+
     "oxlint": ["oxlint@1.68.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.68.0", "@oxlint/binding-android-arm64": "1.68.0", "@oxlint/binding-darwin-arm64": "1.68.0", "@oxlint/binding-darwin-x64": "1.68.0", "@oxlint/binding-freebsd-x64": "1.68.0", "@oxlint/binding-linux-arm-gnueabihf": "1.68.0", "@oxlint/binding-linux-arm-musleabihf": "1.68.0", "@oxlint/binding-linux-arm64-gnu": "1.68.0", "@oxlint/binding-linux-arm64-musl": "1.68.0", "@oxlint/binding-linux-ppc64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-gnu": "1.68.0", "@oxlint/binding-linux-riscv64-musl": "1.68.0", "@oxlint/binding-linux-s390x-gnu": "1.68.0", "@oxlint/binding-linux-x64-gnu": "1.68.0", "@oxlint/binding-linux-x64-musl": "1.68.0", "@oxlint/binding-openharmony-arm64": "1.68.0", "@oxlint/binding-win32-arm64-msvc": "1.68.0", "@oxlint/binding-win32-ia32-msvc": "1.68.0", "@oxlint/binding-win32-x64-msvc": "1.68.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.23.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.23.0", "@oxlint-tsgolint/darwin-x64": "0.23.0", "@oxlint-tsgolint/linux-arm64": "0.23.0", "@oxlint-tsgolint/linux-x64": "0.23.0", "@oxlint-tsgolint/win32-arm64": "0.23.0", "@oxlint-tsgolint/win32-x64": "0.23.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA=="],
@@ -1252,6 +1293,8 @@
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -4,25 +4,20 @@
 	"lineWidth": 100,
 	"indentWidth": 2,
 	"useTabs": true,
-	"biome": {
-		"associations": ["!**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"]
-	},
 	"typescript": {
 		"module.sortImportDeclarations": "maintain",
 		"module.sortExportDeclarations": "maintain",
-		"importDeclaration.sortNamedImports": "maintain"
+		"importDeclaration.sortNamedImports": "maintain",
 	},
-	"markdown": {},
 	"malva": {},
 	"markup": {},
-	"yaml": {},
-	"excludes": ["**/pnpm-lock.yaml", ".serena/project.yml", "public/", "src/assets/"],
+	// Astro files only: oxfmt does not support Astro, so dprint (markup_fmt) keeps handling them.
+	// The typescript and malva plugins remain for embedded scripts and styles inside .astro files.
+	"includes": ["**/*.astro"],
+	"excludes": ["public/", "src/assets/"],
 	"plugins": [
-		"https://plugins.dprint.dev/biome-0.12.12.wasm",
 		"https://plugins.dprint.dev/typescript-0.96.1.wasm",
-		"https://plugins.dprint.dev/markdown-0.22.1.wasm",
 		"https://plugins.dprint.dev/g-plane/malva-v0.16.0.wasm",
 		"https://plugins.dprint.dev/g-plane/markup_fmt-v0.27.3.wasm",
-		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
-	]
+	],
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,9 +19,6 @@ export default defineConfig(
 	},
 	{
 		files: ["**/*.{astro}"],
-		extends: [
-			astroPluginConfigs.recommended,
-			...oxlint.configs["flat/recommended"],
-		],
+		extends: [astroPluginConfigs.recommended, ...oxlint.configs["flat/recommended"]],
 	},
 );

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
 	"name": "portfolio",
 	"version": "1.0.0",
-	"description": "My portfolio with Astro using TypeScript.",
-	"license": "MIT",
 	"private": true,
+	"description": "My portfolio with Astro using TypeScript.",
+	"homepage": "https://roottool.vercel.app",
+	"bugs": {
+		"url": "https://github.com/roottool/portfolio/issues"
+	},
+	"license": "MIT",
 	"author": {
 		"name": "roottool",
 		"url": "https://github.com/roottool"
 	},
-	"homepage": "https://roottool.vercel.app",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/roottool/portfolio.git"
-	},
-	"bugs": {
-		"url": "https://github.com/roottool/portfolio/issues"
 	},
 	"scripts": {
 		"dev": "astro dev",
@@ -23,14 +23,14 @@
 		"astro": "astro",
 		"lint": "run-s -c lint:*",
 		"lint:dprint": "dprint check",
+		"lint:oxfmt": "oxfmt --check",
 		"lint:oxeslint": "astro check && oxlint && eslint --max-warnings=0 .",
 		"lint:markuplint": "markuplint \"**/*.astro\"",
 		"fix": "run-s -c fix:* format",
 		"fix:oxeslint": "oxlint --fix && eslint --fix .",
-		"format": "dprint fmt"
-	},
-	"msw": {
-		"workerDirectory": "public"
+		"format": "run-s -c format:*",
+		"format:oxfmt": "oxfmt",
+		"format:dprint": "dprint fmt"
 	},
 	"dependencies": {
 		"@astrojs/check": "0.9.9",
@@ -52,10 +52,14 @@
 		"globals": "17.6.0",
 		"markuplint": "4.18.3",
 		"npm-run-all2": "9.0.1",
+		"oxfmt": "0.54.0",
 		"oxlint": "1.68.0",
 		"oxlint-tsgolint": "0.23.0",
 		"satori": "0.26.0",
 		"tailwindcss": "4.3.0",
 		"typescript": "6.0.3"
+	},
+	"msw": {
+		"workerDirectory": "public"
 	}
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,8 +40,8 @@ html::after {
 		0deg,
 		transparent,
 		transparent 3px,
-		rgba(0, 0, 0, 0.10) 3px,
-		rgba(0, 0, 0, 0.10) 4px
+		rgba(0, 0, 0, 0.1) 3px,
+		rgba(0, 0, 0, 0.1) 4px
 	);
 	pointer-events: none;
 	z-index: 0;
@@ -104,7 +104,9 @@ body::after {
 }
 
 /* ── Typography ────────────────────────────────────────────── */
-h1, h2, h3 {
+h1,
+h2,
+h3 {
 	font-family: "Cormorant SC", "Noto Serif JP", serif;
 }
 
@@ -131,7 +133,10 @@ h1, h2, h3 {
 		border-radius: 0;
 		border: 1px solid var(--vk-border);
 		position: relative;
-		transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+		transition:
+			border-color 0.3s ease,
+			box-shadow 0.3s ease,
+			background 0.3s ease;
 	}
 
 	.card-base::before,
@@ -205,7 +210,8 @@ h1, h2, h3 {
 }
 
 @keyframes vk-flicker {
-	0%, 100% {
+	0%,
+	100% {
 		opacity: 1;
 	}
 	92% {
@@ -226,8 +232,12 @@ h1, h2, h3 {
 }
 
 @keyframes vk-glitch {
-	0%, 87%, 100% {
-		text-shadow: 0 0 30px rgba(200, 0, 46, 0.4), 0 0 80px rgba(200, 0, 46, 0.1);
+	0%,
+	87%,
+	100% {
+		text-shadow:
+			0 0 30px rgba(200, 0, 46, 0.4),
+			0 0 80px rgba(200, 0, 46, 0.1);
 		transform: none;
 		filter: none;
 	}
@@ -240,12 +250,16 @@ h1, h2, h3 {
 		filter: brightness(1.2);
 	}
 	88.8% {
-		text-shadow: 4px 0 rgba(0, 220, 255, 0.6), -4px 0 rgba(200, 0, 20, 0.85);
+		text-shadow:
+			4px 0 rgba(0, 220, 255, 0.6),
+			-4px 0 rgba(200, 0, 20, 0.85);
 		transform: skewX(2deg) translateX(-2px);
 		filter: none;
 	}
 	89.5% {
-		text-shadow: 0 0 30px rgba(200, 0, 46, 0.4), 0 0 80px rgba(200, 0, 46, 0.1);
+		text-shadow:
+			0 0 30px rgba(200, 0, 46, 0.4),
+			0 0 80px rgba(200, 0, 46, 0.1);
 		transform: none;
 		filter: none;
 	}
@@ -257,7 +271,9 @@ h1, h2, h3 {
 		transform: translateX(2px);
 	}
 	94% {
-		text-shadow: 0 0 30px rgba(200, 0, 46, 0.4), 0 0 80px rgba(200, 0, 46, 0.1);
+		text-shadow:
+			0 0 30px rgba(200, 0, 46, 0.4),
+			0 0 80px rgba(200, 0, 46, 0.1);
 		transform: none;
 	}
 }
@@ -308,7 +324,9 @@ h1, h2, h3 {
 	@keyframes vk-glitch {
 		0%,
 		100% {
-			text-shadow: 0 0 30px rgba(200, 0, 46, 0.4), 0 0 80px rgba(200, 0, 46, 0.1);
+			text-shadow:
+				0 0 30px rgba(200, 0, 46, 0.4),
+				0 0 80px rgba(200, 0, 46, 0.1);
 			transform: none;
 			filter: none;
 		}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
 	"name": "portfolio",
 	"compatibility_date": "2024-10-26",
-	"pages_build_output_dir": "./dist"
+	"pages_build_output_dir": "./dist",
 }


### PR DESCRIPTION
## 概要

フォーマッタを dprint から可能な限り [oxfmt](https://oxc.rs/docs/guide/usage/formatter) (0.54.0) へ移行します。

## 調査結果: oxfmt の対応状況

oxc モノレポの `apps/oxfmt/src/core/support.rs` を確認した結果:

| 種別 | 対応 | 備考 |
| --- | --- | --- |
| JS / TS / JSX / TSX | ✅ ネイティブ (Rust) | |
| JSON / JSONC / JSON5 / TOML | ✅ ネイティブ (Rust) | `package.json` は sort-package-json で自動ソート |
| YAML / Markdown / CSS / HTML | ✅ 内蔵 Prettier 経由 (napi) | |
| **Astro** | ❌ **非対応** | external parser リストに `astro` が存在しない |

### Astro ファイルの方針: dprint 維持を選択

- **Biome**: Astro は frontmatter のみの部分対応でテンプレート部分を整形できないため不採用
- **Prettier + prettier-plugin-astro**: 新規依存が2つ増え、既存の markup_fmt と整形結果が変わり `.astro` に差分が発生するため不採用
- **dprint 維持(採用)**: `dprint.jsonc` の対象を `**/*.astro` のみに限定。markup_fmt が `.astro` 全体を、typescript / malva プラグインが埋め込みスクリプト・スタイルを引き続き整形。既存ファイルへの差分ゼロ

## 変更内容

- `.oxfmtrc.json` 新規追加(既存スタイルに合わせ tabs / printWidth 100、yml・md はスペースインデント)
- `dprint.jsonc` を `.astro` 専用に縮小(biome / markdown / pretty_yaml プラグイン削除)
- `package.json`: `lint:oxfmt` / `format:oxfmt` / `format:dprint` スクリプト追加、`oxfmt` を devDependencies に追加
- CI (`ci.yml`): フォーマットチェックを oxfmt + dprint の2ステップに分割、renovate-config-lint も oxfmt に変更
- `update-oss-contributions.yml` / `update-owned-games.yml`: JSON 整形を `bunx oxfmt` に変更
- VSCode: `.astro` 以外の defaultFormatter を `oxc.oxc-vscode` に変更(oxfmt は拡張のデフォルトで有効、`node_modules` のバイナリを自動検出)、拡張機能の推奨に追加
- oxfmt 適用による整形差分: `src/styles/global.css`(セレクタ・複数値プロパティの改行)、`eslint.config.mjs`、`package.json`(キーソート)、`wrangler.jsonc` / `dprint.jsonc`(JSONC 末尾カンマ)

## 検証

- `bun run lint:oxfmt` ✅ (29ファイル)
- `bun run lint:dprint` ✅ (`.astro` 5ファイルのみ対象になることを `dprint output-file-paths` で確認)
- `bunx oxlint` / `bunx tsc --noEmit` ✅
- `astro check` / ESLint / markuplint はローカルサンドボックスの制限で実行不可のため CI にて確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 開発ツール設定を更新し、コードフォーマッティングパイプラインを最適化しました。
  * CI/CDワークフローを改善し、自動化プロセスの効率性を向上させました。
  * VSCode推奨拡張機能と設定を更新しました。
  * Wrangler設定にビルド出力先を明示化しました。

* **Documentation**
  * 開発コマンドの説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->