### PR TITLE
fix: address web best practices audit findings

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), microphone=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload

--- a/src/components/GitHubContributions.astro
+++ b/src/components/GitHubContributions.astro
@@ -70,7 +70,8 @@ const formattedContributions = processContributions(data);
 	opacity: 0;
 	transition: opacity 0.3s ease;
 }
-.group:hover .accent-bar {
+.group:hover .accent-bar,
+.group:focus-within .accent-bar {
 	opacity: 1;
 }
 </style>

--- a/src/components/SpotifyRecent.astro
+++ b/src/components/SpotifyRecent.astro
@@ -25,7 +25,7 @@
 			style="border-radius: 0; display: block"
 			src="https://open.spotify.com/embed/playlist/37i9dQZEVXd8D7v4N65TZe?utm_source=generator&theme=0"
 			height="352"
-			allowfullscreen=""
+			allowfullscreen
 			allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
 			loading="lazy"
 			class="border-0 w-full"

--- a/src/components/SteamSummary.astro
+++ b/src/components/SteamSummary.astro
@@ -40,7 +40,7 @@ const games = processGames(data.games).slice(0, 12);
 						class="game-image w-full object-cover transition-all duration-500"
 						loading={index < 6 ? "eager" : "lazy"}
 						decoding="async"
-						fetchpriority={index < 6 ? "high" : "low"}
+						fetchpriority={index < 6 ? "high" : undefined}
 						width="231"
 						height="87"
 					/>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import cinzelDecorative700 from "@fontsource/cinzel-decorative/files/cinzel-decorative-latin-700-normal.woff2?url";
+
 import GitHubLogo from "../assets/logo/github.svg";
 import XLogo from "../assets/logo/x.svg";
 
@@ -6,6 +8,7 @@ import "../styles/global.css";
 
 const NAME = "roottool" as const satisfies string;
 const { title = NAME } = Astro.props;
+const year = new Date().getFullYear();
 ---
 
 <html lang="ja" style="background-color: #060008; color: #e8dff2">
@@ -13,6 +16,7 @@ const { title = NAME } = Astro.props;
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#060008" />
+		<meta name="color-scheme" content="dark" />
 		<meta
 			name="description"
 			content="roottool — web app developer and Visual Kei enthusiast."
@@ -20,6 +24,7 @@ const { title = NAME } = Astro.props;
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@roottool" />
 		<meta name="twitter:image" content="https://portfolio-6od.pages.dev/og.png" />
+		<meta property="og:type" content="website" />
 		<meta property="og:title" content="roottool" />
 		<meta
 			property="og:description"
@@ -31,16 +36,23 @@ const { title = NAME } = Astro.props;
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
+		<link rel="canonical" href="https://portfolio-6od.pages.dev/" />
 		<link rel="manifest" href="/manifest.json" />
 		<link rel="icon" href="/favicon.ico" />
 		<link rel="apple-touch-icon" href="/android-chrome-192x192.png" />
 		<link rel="preconnect" href="https://cdn.cloudflare.steamstatic.com" />
+		<link rel="preconnect" href="https://open.spotify.com" />
+		<link rel="preconnect" href="https://i.scdn.co" />
+		<link
+			rel="preload"
+			href={cinzelDecorative700}
+			as="font"
+			type="font/woff2"
+			crossorigin
+		/>
 		<title>{title}</title>
 	</head>
-	<body
-		class="grid grid-areas-layout grid-rows-[max-content_1fr_max-content] xl:h-screen xl:overflow-hidden"
-		style="position: relative; z-index: 1"
-	>
+	<body class="grid grid-areas-layout grid-rows-[max-content_1fr_max-content] xl:h-screen xl:overflow-hidden">
 		<a href="#main-content" class="skip-link">Skip to main content</a>
 
 		<!-- Header -->
@@ -93,6 +105,7 @@ const { title = NAME } = Astro.props;
 		<!-- Main content -->
 		<main
 			id="main-content"
+			tabindex="-1"
 			class="grid-area-main max-w-7xl mx-auto w-full px-4 sm:px-8 py-10 xl:overflow-hidden grid xl:grid-rows-1 gap-8 sm:grid-cols-2 xl:grid-cols-[3fr_2fr]"
 			style="animation: vk-fade-in 0.9s 0.4s ease both"
 		>
@@ -125,7 +138,7 @@ const { title = NAME } = Astro.props;
 				</a>
 			</div>
 			<p style='font-family: "Cormorant SC", serif; font-size: 0.75rem; letter-spacing: 0.3em; color: var(--vk-muted); text-transform: uppercase'>
-				© 2025 &nbsp;{NAME}
+				© {year} &nbsp;{NAME}
 			</p>
 		</footer>
 	</body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,6 +71,8 @@ html::after {
 body {
 	position: relative;
 	background-color: var(--vk-bg);
+	/* Layer body content above the html::after scanlines (z-index: 0) */
+	z-index: 1;
 }
 
 /* Deep radial vignette */


### PR DESCRIPTION
## 概要

2026-05-21 実施の Web ベストプラクティス監査レポート(`web-best-practices-report.html`)で指摘された High 5件・Medium 4件・Low 2件の全11件を修正します。

## 変更理由

パフォーマンス・アクセシビリティ・HTML/SEO・セキュリティの4観点の監査で改善点が指摘されていました。レポート生成から約3週間経過していたため、各指摘箇所が現在のコードでも該当することを確認したうえで修正しています。

## 変更内容

### Performance

- lazy 画像への `fetchpriority="low"` 併用を削除しました。lazy 画像はビューポート進入後もフェッチ優先度が低いまま固定されるため、ガイドは併用を禁止しています
- Spotify iframe 向けに `open.spotify.com` と `i.scdn.co` の preconnect を追加しました。`i.scdn.co` はネットワークパーティショニングにより iframe 内部リクエストへの効果が限定的ですが、無害なためレポート通り追加しています
- h1 で使う Cinzel Decorative 700 の preload を追加しました。レポートは静的パス `/fonts/...` を提案していましたが、`@fontsource` のフォントは Vite が `/_astro/<hash>.woff2` にバンドルするため、`?url` import でハッシュ済み URL を解決する方式に変えています

### Accessibility

- スキップリンク先の `<main>` に `tabindex="-1"` を付与し、プログラムによるフォーカス移動を確実にしました
- GitHub カードの `.accent-bar` を `:focus-within` でも表示し、キーボード操作時の視覚フィードバックを hover と揃えました
- `color-scheme` メタタグでスクロールバーなどの UA 描画をダークテーマに合わせました

### HTML / SEO

- body の inline style を `global.css` へ移動しました。`position: relative` は重複定義、`z-index: 1` はスタイルシートに置くべき静的スタイルでした
- `og:type`・`canonical` リンクを追加しました
- フッターの Copyright 年をビルド時の動的値に変更しました
- `allowfullscreen=""` の冗長な空文字列値を削除しました

### Security

- Cloudflare Pages の `public/_headers` でセキュリティヘッダーを追加しました。`Strict-Transport-Security` は `*.pages.dev` が HSTS preload 済みのため現状は冗長ですが、独自ドメイン移行時の保険として含めています

## テスト

- [x] oxfmt・dprint・oxlint・tsc の通過を確認
- [ ] astro check・ESLint・markuplint・ビルドは CI で確認(ローカルはサンドボックスの読み取り制限で実行不可)

## 関連情報

- 参考資料: `web-best-practices-report.html`(リポジトリ未追跡のローカル監査レポート)

## 署名

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SEOメタタグ設定とマニフェスト統合を追加
  * フォント事前読み込みによるパフォーマンス向上

* **アクセシビリティ**
  * キーボードナビゲーション対応を改善
  * フォーカス時のビジュアルフィードバック強化

* **バグ修正**
  * レイアウト要素の重ね合わせ順序を修正

* **Chores**
  * セキュリティレスポンスヘッダを追加設定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->