### PR TITLE
fix: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/update-oss-contributions.yml
+++ b/.github/workflows/update-oss-contributions.yml
@@ -74,7 +74,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Create Data Update PR

--- a/.github/workflows/update-oss-contributions.yml
+++ b/.github/workflows/update-oss-contributions.yml
@@ -74,7 +74,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Create Data Update PR

--- a/.github/workflows/update-owned-games.yml
+++ b/.github/workflows/update-owned-games.yml
@@ -81,7 +81,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Create Data Update PR

--- a/.github/workflows/update-owned-games.yml
+++ b/.github/workflows/update-owned-games.yml
@@ -81,7 +81,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Create Data Update PR


### PR DESCRIPTION
## Overview

Replace the deprecated `app-id` input with `client-id` in the two workflows that use `actions/create-github-app-token`.

## Motivation

Both workflows emit the following warning on every run:

> Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Renaming the input eliminates the noise.

## Changes

- `update-owned-games.yml` and `update-oss-contributions.yml`: `app-id:` → `client-id:`
- The referenced variable (`vars.GH_APP_ID`) is unchanged; the rename is input-name only.

## Testing

- [ ] CI passes on this PR

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自動更新用の認証処理で必要な情報が追加され、GitHub App のトークン生成がより安定しました。
  * 既存の自動更新フローはそのまま維持され、関連する定期更新処理の失敗リスクが低減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->