### PR TITLE
fix: export astro and lint-config outputs from setup job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       pull-requests: read
     outputs:
       typescript: ${{ steps.filter.outputs.typescript }}
+      astro: ${{ steps.filter.outputs.astro }}
+      lint-config: ${{ steps.filter.outputs.lint-config }}
       renovate-config: ${{ steps.filter.outputs.renovate-config }}
     if: ${{ !github.event.pull_request.draft }}
     steps:


### PR DESCRIPTION
## Summary
- The `setup` job's `paths-filter` step evaluates `typescript` / `astro` / `lint-config` / `renovate-config`, but only `typescript` and `renovate-config` were declared as job outputs.
- As a result, `needs.setup.outputs.astro` was always falsy, so the **Markuplint step has never run in CI**, even for PRs that touch `.astro` files.
- Similarly, `needs.setup.outputs.lint-config` was always falsy, so oxlint/eslint were skipped for PRs that only change lint configuration.
- This PR adds the two missing `outputs:` entries so both checks actually gate on their intended path filters.

## Test plan
- [x] `bunx oxfmt --check .github/workflows/ci.yml` passes
- [ ] Confirm in CI that this PR (no `.astro` changes) still correctly skips Markuplint
- [ ] After merge, confirm a future PR touching `.astro` files actually runs the Markuplint step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI の判定対象に新しい変更種別が追加され、以降のジョブで追加の出力値を利用できるようになりました。
  * これにより、関連するチェックやワークフローの分岐がより正確に実行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->