### PR TITLE
feat: add Visual Kei styled 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,31 @@
+---
+import Layout from "@/layouts/Layout.astro";
+---
+
+<Layout title="404 — roottool">
+	<section class="col-span-full flex flex-col items-center justify-center gap-6 py-16 text-center vk-animate-in">
+		<p
+			class="text-xs tracking-[0.5em] uppercase"
+			style='color: var(--vk-crimson); font-family: "Cormorant SC", serif'
+		>
+			Lost in the Abyss
+		</p>
+		<h2 style='font-family: "Cinzel Decorative", serif; font-size: clamp(4rem, 12vw, 8rem); font-weight: 700; color: var(--vk-text); text-shadow: var(--vk-glow); line-height: 1'>
+			404
+		</h2>
+		<div class="vk-divider w-48" aria-hidden="true">✦</div>
+		<p
+			class="text-lg"
+			style='color: var(--vk-muted); font-family: "Cormorant Garamond", serif; font-style: italic'
+		>
+			This page has faded into the void.
+		</p>
+		<a
+			href="/"
+			class="card-base px-6 py-3 mt-2"
+			style='font-family: "Cormorant SC", serif; letter-spacing: 0.15em; text-transform: uppercase; color: var(--vk-silver)'
+		>
+			Return to the Sanctuary
+		</a>
+	</section>
+</Layout>


### PR DESCRIPTION
## Summary
- `src/pages/` previously only had `index.astro`. Cloudflare Pages automatically adopts `dist/404.html` as a custom 404 page once it exists, so this adds one that follows the Visual Kei design system (color tokens only, the three established fonts, `card-base` / `vk-divider` / `vk-animate-in` utilities — no new patterns invented).
- Reviewed by the `visual-kei-reviewer` agent: approved, with one DRY suggestion (use the `vk-animate-in` utility class instead of an inline `animation` style) applied.
- No `vk-section-title` on the "404" heading — it's a hero-scale decorative numeral (same treatment as the site's `h1` brand heading in `Layout.astro`), not a list-section label, so that pattern doesn't apply here.

## Test plan
- [x] `bunx oxfmt --check .` / `bunx dprint check` / `bunx oxlint` / `bunx tsc --noEmit` all pass
- [ ] CI green (`astro build` confirms `dist/404.html` is generated)
- [ ] After merge, visit a non-existent path (e.g. `/nowhere`) on the deployed site and confirm the custom 404 renders
- [ ] Optional: check the page doesn't clip vertically at the `xl` breakpoint (short/wide viewports), since `Layout.astro`'s `<main>` is `xl:overflow-hidden`

🤖 Generated with [Claude Code](https://claude.com/claude-code)