### PR TITLE
feat: add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary
- Adds `public/robots.txt` allowing all crawlers, including AI training bots (GPTBot, ClaudeBot, CCBot, etc.).
- Rationale: this site publishes no personal or career information — only public GitHub/Steam/Spotify data and design — so there's no sensitive content at stake, and a portfolio site benefits more from being discoverable than from being blocked. `Disallow` is also purely advisory (well-behaved crawlers only), so it wouldn't meaningfully stop anything anyway.
- No `Sitemap:` line — the site has no sitemap and is a single page, so it wouldn't add value.

## Test plan
- [x] `bunx oxfmt --check .` / `bunx dprint check` pass
- [ ] After merge, confirm `https://portfolio-6od.pages.dev/robots.txt` serves the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)