### PR TITLE
fix: allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), geolocation=(), microphone=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'none'; img-src 'self' https://cdn.cloudflare.steamstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://open.spotify.com; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'
+  Content-Security-Policy: default-src 'none'; script-src https://static.cloudflareinsights.com; connect-src https://cloudflareinsights.com; img-src 'self' https://cdn.cloudflare.steamstatic.com; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://open.spotify.com; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- After merging the CSP from #2522, real-machine verification (production URL) surfaced one actual violation: `static.cloudflareinsights.com/beacon.min.js` — the Web Analytics beacon Cloudflare Pages auto-injects for this project — was blocked by `default-src 'none'`, since no `script-src`/`connect-src` was specified.
- Per Cloudflare's own CSP guidance for Web Analytics, adds `script-src https://static.cloudflareinsights.com` and `connect-src https://cloudflareinsights.com`.
- Decision: keep Web Analytics enabled (vs. turning it off in the Cloudflare dashboard) — it's cookie-free/low-privacy-risk and gives actual visit visibility for a portfolio site, which outweighs the "zero third-party network calls" purity angle.
- The other console output from the real-machine check (`allowfullscreen` attribute precedence, PlayReady/robustness-level, `setServerCertificate`) are pre-existing informational warnings from the Spotify iframe's own internal DRM negotiation, not CSP violations — no action needed.

## Test plan
- [x] `bunx oxfmt --check .` / `bunx dprint check` pass
- [ ] CI green
- [x] After merge, confirm the beacon loads without a CSP violation on the production URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)