### PR TITLE
chore: harden data pipelines and remove leftover config

### DIFF
--- a/.github/workflows/update-oss-contributions.yml
+++ b/.github/workflows/update-oss-contributions.yml
@@ -47,11 +47,17 @@ jobs:
             --author "roottool" \
             --merged \
             --visibility "public" \
+            --limit 100 \
             --json id,number,title,url,repository,closedAt \
             -- -user:"roottool" \
             > temp-contributions.json
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Validate JSON structure
+        run: |
+          jq -e 'type == "array" and all(.[]; has("closedAt") and has("title") and has("url") and has("repository"))' \
+            temp-contributions.json > /dev/null
 
       - name: Format and move JSON
         run: |

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@resvg/resvg-js": "2.6.2",
         "@tailwindcss/vite": "4.3.2",
         "@types/node": "26.1.0",
+        "@typescript-eslint/parser": "8.62.1",
         "dprint": "0.55.1",
         "eslint": "10.6.0",
         "eslint-config-flat-gitignore": "2.3.0",
@@ -577,9 +578,17 @@
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@5.0.0", "", {}, "sha512-YYiBDCoqBgDIF2ByYn4qDb4RaXZ46cOQ6j2We1Ni3bikFNI7YFeL8jxSiYowWsriZrb1mw09CLZ+b+ZkIhsLVw=="],
 
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.62.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.62.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.62.1", "@typescript-eslint/types": "^8.62.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg=="],
+
     "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1" } }, "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg=="],
 
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.62.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g=="],
+
     "@typescript-eslint/types": ["@typescript-eslint/types@8.62.1", "", {}, "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.62.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.62.1", "@typescript-eslint/tsconfig-utils": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g=="],
 
@@ -1230,6 +1239,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig(
 		},
 	},
 	{
-		files: ["**/*.{astro}"],
+		files: ["**/*.astro"],
 		extends: [astroPluginConfigs.recommended, ...oxlint.configs["flat/recommended"]],
 	},
 );

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@resvg/resvg-js": "2.6.2",
 		"@tailwindcss/vite": "4.3.2",
 		"@types/node": "26.1.0",
+		"@typescript-eslint/parser": "8.62.1",
 		"dprint": "0.55.1",
 		"eslint": "10.6.0",
 		"eslint-config-flat-gitignore": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
 		"satori": "0.26.0",
 		"tailwindcss": "4.3.2",
 		"typescript": "6.0.3"
-	},
-	"msw": {
-		"workerDirectory": "public"
 	}
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,8 +18,9 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": "/",
   "display": "standalone",
+  "description": "roottool — web app developer and Visual Kei enthusiast.",
   "theme_color": "#060008",
   "background_color": "#060008"
 }

--- a/src/components/SpotifyRecent.astro
+++ b/src/components/SpotifyRecent.astro
@@ -20,7 +20,6 @@
 		></span>
 
 		<iframe
-			data-testid="embed-iframe"
 			title="Soundtrack"
 			style="border-radius: 0; display: block"
 			src="https://open.spotify.com/embed/playlist/37i9dQZEVXd8D7v4N65TZe?utm_source=generator&theme=0"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -54,6 +54,7 @@ const jsonLd = {
 		<meta property="og:url" content={canonicalURL} />
 		<link rel="canonical" href={canonicalURL} />
 		<script
+			is:inline
 			type="application/ld+json"
 			set:html={JSON.stringify(jsonLd).replace(/</g, "\\u003c")}
 		/>

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,13 +1,15 @@
 /**
- * Formats a Date object into YYYY/MM/DD format
+ * Formats a Date object into YYYY/MM/DD format (fixed to Asia/Tokyo)
  * @param date - The date to format
  * @returns Formatted date string in YYYY/MM/DD format
  * @example
- * formatDate(new Date('2024-03-15')) // Returns '2024/03/15'
+ * formatDate(new Date('2024-03-15T20:00:00Z')) // Returns '2024/03/16' (JST)
  */
 export const formatDate = (date: Date): string => {
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, "0");
-	const day = String(date.getDate()).padStart(2, "0");
-	return `${year}/${month}/${day}`;
+	return new Intl.DateTimeFormat("ja-JP", {
+		timeZone: "Asia/Tokyo",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
 };


### PR DESCRIPTION
Pipeline hardening:
- gh search prs now passes --limit 100 instead of relying on the implicit default of 30, so it reliably captures all merged PRs.
- Add a JSON structure validation step for oss-contributions, mirroring the one already used for owned-games.
- formatDate() now fixes its output to Asia/Tokyo instead of the build environment's local timezone (UTC in CI), which could previously show a date up to a day off from JST. Display format is unchanged ('ja-JP' with explicit y/m/d options still renders as YYYY/MM/DD) — some dates may shift by one day, in the correct direction.

Leftover cleanup:
- Remove the "msw" config block from package.json — msw isn't a dependency, so this was dead config.
- Remove data-testid="embed-iframe" from SpotifyRecent.astro, a leftover from copy-pasting Spotify's embed snippet.
- manifest.json: start_url now points at "/" instead of "./index.html", and adds a description field.
- eslint.config.mjs: files: ["**/*.astro"] instead of the equivalent but confusing brace-glob ["**/*.{astro}"].

**Follow-up finding:** the brace-glob fix above wasn't just cosmetic — `{astro}` without a comma isn't valid brace-expansion, so the old glob never matched any real `.astro` file, meaning the Astro-specific ESLint block had silently never run. Fixing it activated that block for the first time and surfaced a real gap: `@typescript-eslint/parser` (an optional peer of eslint-plugin-astro, needed to parse TS inside Astro frontmatter) wasn't installed, so every `.astro` file using TS syntax failed to parse. Installed it, and added `is:inline` to the JSON-LD `<script>` in Layout.astro to silence an `astro check` hint (no behavior change — Astro already treats it as inline).

## Test plan
- [x] `bunx oxfmt --check .` / `bunx dprint check` / `bunx oxlint` / `bunx tsc --noEmit` pass
- [x] `astro check && oxlint && eslint --max-warnings=0 .` run by the user locally: 0 errors, 0 warnings, 0 hints
- [ ] CI green
- [ ] After merge, run the OSS contributions workflow and confirm the validation step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PWA の起動先設定と説明文を更新し、アプリの起動体験を改善しました。

* **Bug Fixes**
  * 日付表示を日本時間基準で統一し、表示ずれが起きにくくなりました。
  * 外部データ取得時の確認を強化し、想定外の形式の内容で処理が進まないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->