### PR TITLE
feat: add data-freshness note and source link to footer

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -161,6 +161,20 @@ const jsonLd = {
 			<p style='font-family: "Cormorant SC", serif; font-size: 0.75rem; letter-spacing: 0.3em; color: var(--vk-muted); text-transform: uppercase'>
 				© {year} &nbsp;{NAME}
 			</p>
+			<p
+				class="mt-2"
+				style='font-family: "Cormorant SC", serif; font-size: 0.65rem; letter-spacing: 0.15em; color: var(--vk-silver-dim); text-transform: uppercase'
+			>
+				Data auto-updated weekly &nbsp;·&nbsp;
+				<a
+					href="https://github.com/roottool/portfolio"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="footer-link"
+				>
+					View the source
+				</a>
+			</p>
 		</footer>
 	</body>
 </html>


### PR DESCRIPTION
## Summary
Scaled down from the originally planned full "site colophon" section (a tech-stack brag list: zero-JS, Astro, Tailwind, Cloudflare Pages). Those items were cut as low-value self-promotion with no payoff for the visitor, and partial overlap with the tech-stack-section idea (shelved separately).

Kept only the two items with actual reader value, added as one small line under the existing copyright in the footer:
- "Data auto-updated weekly" — explains why the Contributions/Steam sections above aren't a stale snapshot.
- "View the source" — directly actionable for the portfolio's likely audience (developers, recruiters).

Reuses the existing `.footer-link` hover style rather than introducing a new component or duplicate CSS.

## Test plan
- [x] `bunx oxfmt --check .` / `bunx dprint check` / `bunx oxlint` / `bunx tsc --noEmit` all pass
- [ ] CI green
- [ ] After merge, visually confirm via `bun run dev` that the new footer line doesn't crowd the existing copyright line at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)